### PR TITLE
Add errata on page 217, listing 10-6

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -11,3 +11,9 @@ On **page xx** [Summary of error]:
 Details of error here. Highlight key pieces in **bold**.
 
 ***
+
+On **page 217** [Premature change in listing 10-6]:
+ 
+The **`price?` property** has mistakenly been made optional in listing 10-6. The line should remain as in listing 10-5 to make sense together with the text.
+
+***


### PR DESCRIPTION
The price? property has mistakenly been made optional in listing 10-6. The line should remain as in listing 10-5 to make sense together with the text.